### PR TITLE
Fix: Remove EnableCompressionInSingleFile (not supported with SelfCon…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -140,7 +140,7 @@ jobs:
         run: dotnet restore RunAsAdmin/RunAsAdmin.csproj
 
       - name: Publish Single-File Release
-        run: dotnet publish RunAsAdmin/RunAsAdmin.csproj -c Release -r win-x64 --self-contained false -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true -p:EnableCompressionInSingleFile=true -p:DebugType=None -p:DebugSymbols=false
+        run: dotnet publish RunAsAdmin/RunAsAdmin.csproj -c Release -r win-x64 --self-contained false -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true -p:DebugType=None -p:DebugSymbols=false
 
       - name: Create Release Package
         id: create_package

--- a/RunAsAdmin/RunAsAdmin.csproj
+++ b/RunAsAdmin/RunAsAdmin.csproj
@@ -13,7 +13,6 @@
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <SelfContained>false</SelfContained>
     <IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
-    <EnableCompressionInSingleFile>true</EnableCompressionInSingleFile>
     <PublishReadyToRun>false</PublishReadyToRun>
   </PropertyGroup>
 


### PR DESCRIPTION
…tained=false)

Error fixed:
NETSDK1176: Compression in a single file bundle is only supported when publishing a self-contained application.

Changes:
- Removed EnableCompressionInSingleFile from .csproj PropertyGroup
- Removed -p:EnableCompressionInSingleFile=true from dotnet publish command in release workflow

Technical details:
- Single-file compression only works with SelfContained=true
- Since we use SelfContained=false (requires .NET 8 Runtime on host), compression is not available
- Single-file exe will still be created, just without compression
- The exe will be slightly larger but still a single file

The application will:
- Be published as a single RunAsAdmin.exe
- Require .NET 8 Desktop Runtime on the host system
- Show installation dialog if .NET 8 is not present