### PR TITLE
Fix runtime errors for single-file publish and non-AD environments

### DIFF
--- a/RunAsAdmin/Core/Helper.cs
+++ b/RunAsAdmin/Core/Helper.cs
@@ -80,6 +80,11 @@ namespace RunAsAdmin.Core
                 GlobalVars.Loggi.Warning(adEx, "Active Directory not available, returning only local machine");
                 return domainList;
             }
+            catch (ActiveDirectoryOperationException adOpEx)
+            {
+                GlobalVars.Loggi.Warning(adOpEx, "Not associated with Active Directory domain or forest, returning only local machine");
+                return domainList;
+            }
             catch (Exception ex)
             {
                 GlobalVars.Loggi.Error(ex, "Error retrieving domain list, returning only local machine");
@@ -156,6 +161,11 @@ namespace RunAsAdmin.Core
             catch (ActiveDirectoryObjectNotFoundException adEx)
             {
                 GlobalVars.Loggi.Warning(adEx, "Active Directory not available");
+                return ADUsers;
+            }
+            catch (ActiveDirectoryOperationException adOpEx)
+            {
+                GlobalVars.Loggi.Warning(adOpEx, "Not associated with Active Directory domain or forest");
                 return ADUsers;
             }
             catch (PrincipalServerDownException psEx)

--- a/RunAsAdmin/Core/SecurityHelper.cs
+++ b/RunAsAdmin/Core/SecurityHelper.cs
@@ -72,7 +72,7 @@ namespace RunAsAdmin.Core
                 if (string.IsNullOrEmpty(textToDecrypt))
                 {
                     GlobalVars.Loggi.Warning("Decrypt called with null or empty string");
-                    return null;
+                    return string.Empty;
                 }
 
                 // Convert from Base64
@@ -92,18 +92,18 @@ namespace RunAsAdmin.Core
             }
             catch (FormatException formatEx)
             {
-                GlobalVars.Loggi.Error(formatEx, "Invalid Base64 format during decryption: {Message}", formatEx.Message);
-                throw new ArgumentException("The encrypted text is not in a valid format", nameof(textToDecrypt), formatEx);
+                GlobalVars.Loggi.Warning(formatEx, "Invalid Base64 format during decryption, returning empty string");
+                return string.Empty;
             }
             catch (CryptographicException cryptoEx)
             {
-                GlobalVars.Loggi.Error(cryptoEx, "Cryptographic error during decryption: {Message}", cryptoEx.Message);
-                throw new InvalidOperationException("Failed to decrypt data. The data may have been encrypted by a different user or machine.", cryptoEx);
+                GlobalVars.Loggi.Warning(cryptoEx, "Cryptographic error during decryption (data may be encrypted by different user/machine), returning empty string");
+                return string.Empty;
             }
             catch (Exception ex)
             {
-                GlobalVars.Loggi.Error(ex, "Unexpected error during decryption: {Message}", ex.Message);
-                throw new InvalidOperationException("Decryption failed", ex);
+                GlobalVars.Loggi.Warning(ex, "Unexpected error during decryption, returning empty string");
+                return string.Empty;
             }
         }
 


### PR DESCRIPTION
This commit addresses multiple runtime exceptions:

1. Fixed ActiveDirectoryOperationException when not joined to AD domain
   - Added catch handlers for ActiveDirectoryOperationException in GetADUsers() and GetAllDomains()
   - Now gracefully returns local users/machine name when AD is not available

2. Fixed DirectoryNotFoundException in InitializeUserRightInfoLabel()
   - Added fallback to Environment.ProcessPath for single-file published apps
   - Added proper validation before calling UACHelper.GetExpectedRunLevel()
   - Returns "Unknown" or "Unable to determine" when assembly location is unavailable

3. Fixed CryptographicException in SecurityHelper.Decrypt()
   - Changed exception handling to return empty string instead of throwing
   - Prevents crashes when decrypting data encrypted by different user/machine
   - Changed from Error to Warning level logging for better user experience

4. Fixed DriveInfo ArgumentException in InitializeStartUpDetails()
   - Added fallback to Environment.ProcessPath for single-file apps
   - Properly extracts root drive path using Path.GetPathRoot()
   - Added validation before creating DriveInfo instance

All fixes include proper logging and graceful degradation for better reliability.